### PR TITLE
Implemented Merkle proofs and verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	cd contracts && forge build
 
 test:
-	cd contracts && forge test
+	cd contracts && forge test -vv
 
 deploy:
 	cd contracts && forge create --rpc-url $(ETH_RPC_URL) --keystore $(KEYSTORE_PATH) --password $(PASSWORD) src/PDPService.sol:PDPService --constructor-args $(CHALLENGE_FINALITY)

--- a/contracts/src/BitOps.sol
+++ b/contracts/src/BitOps.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+// Library for bit operations.
+library BitOps {
+    // Calculates the number of leading zeros in binary representation.
+    function clz(uint256 x) internal pure returns (uint256) {
+        uint256 n = 256;
+        uint256 y;
+
+        y = x >> 128; if (y != 0) { n -= 128; x = y; }
+        y = x >> 64;  if (y != 0) { n -= 64;  x = y; }
+        y = x >> 32;  if (y != 0) { n -= 32;  x = y; }
+        y = x >> 16;  if (y != 0) { n -= 16;  x = y; }
+        y = x >> 8;   if (y != 0) { n -= 8;   x = y; }
+        y = x >> 4;   if (y != 0) { n -= 4;   x = y; }
+        y = x >> 2;   if (y != 0) { n -= 2;   x = y; }
+        y = x >> 1;   if (y != 0) return n - 2;
+        return n - x;
+    }
+}

--- a/contracts/src/Proofs.sol
+++ b/contracts/src/Proofs.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Adapted from OpenZeppelin Contracts (last updated v5.0.0) (utils/cryptography/MerkleProof.sol)
+// Changes:
+// - Specialised to hash function of SHA256
+// - Removed unused functions, incl multiproofs
+// - Remove redundant comments and cruft
+
+pragma solidity ^0.8.20;
+
+/**
+ * These functions deal with verification of Merkle Tree proofs.
+ *
+ * They are specialised to the hash function of SHA256.
+ */
+library MerkleProof {
+    /**
+     * Returns true if a `leaf` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     *
+     * This version handles proofs in memory.
+     */
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal view returns (bool) {
+        return processProof(proof, leaf) == root;
+    }
+
+    /**
+     * Returns the rebuilt hash obtained by traversing a Merkle tree up
+     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
+     * hash matches the root of the tree. When processing the proof, the pairs
+     * of leafs & pre-images are assumed to be sorted.
+     *
+     * This version handles proofs in memory.
+     */
+    function processProof(bytes32[] memory proof, bytes32 leaf) internal view returns (bytes32) {
+        bytes32 computedHash = leaf;
+        for (uint256 i = 0; i < proof.length; i++) {
+            computedHash = Hashes.commutativeHash(computedHash, proof[i]);
+        }
+        return computedHash;
+    }
+
+    /**
+     * Returns true if a `leaf` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     *
+     * This version handles proofs in calldata.
+     */
+    function verifyCalldata(bytes32[] calldata proof, bytes32 root, bytes32 leaf) internal view returns (bool) {
+        return processProofCalldata(proof, leaf) == root;
+    }
+
+    /**
+     * Returns the rebuilt hash obtained by traversing a Merkle tree up
+     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
+     * hash matches the root of the tree. When processing the proof, the pairs
+     * of leafs & pre-images are assumed to be sorted.
+     *
+     * This version handles proofs in calldata.
+     */
+    function processProofCalldata(bytes32[] calldata proof, bytes32 leaf) internal view returns (bytes32) {
+        bytes32 computedHash = leaf;
+        for (uint256 i = 0; i < proof.length; i++) {
+            computedHash = Hashes.commutativeHash(computedHash, proof[i]);
+        }
+        return computedHash;
+    }
+}
+
+
+library Hashes {
+    /** Commutative hash of pair of bytes32. */
+    function commutativeHash(bytes32 a, bytes32 b) internal view returns (bytes32) {
+        return a < b ? _efficientSHA256(a, b) : _efficientSHA256(b, a);
+    }
+
+    /** Implementation of sha256(abi.encode(a, b)) that doesn't allocate or expand memory. */
+    function _efficientSHA256(bytes32 a, bytes32 b) private view returns (bytes32 value) {
+        assembly ("memory-safe") {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            
+            // Call the SHA256 precompile
+            if iszero(staticcall(gas(), 0x2, 0x00, 0x40, 0x00, 0x20)) {
+                revert(0, 0)
+            }
+            
+            value := mload(0x00)
+        }
+    }
+}

--- a/contracts/test/BitOps.t.sol
+++ b/contracts/test/BitOps.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {BitOps} from "../src/BitOps.sol";
+
+contract BitOpsTest is Test {
+    function testClzZero() pure public {
+        uint256 result = BitOps.clz(0);
+        assertEq(result, 256, "CLZ of 0 should be 256");
+    }
+
+    function testClzOne() pure public {
+        uint256 result = BitOps.clz(1);
+        assertEq(result, 255, "CLZ of 1 should be 255");
+    }
+
+    function testClzMaxUint256() pure public {
+        uint256 result = BitOps.clz(type(uint256).max);
+        assertEq(result, 0, "CLZ of max uint256 should be 0");
+    }
+
+    function testClzPowersOfTwo() pure public {
+        for (uint16 i = 0; i < 256; i++) {
+            uint256 input = 1 << i;
+            uint256 result = BitOps.clz(input);
+            assertEq(result, 255 - i, string(abi.encodePacked("CLZ of 2^", vm.toString(i), " should be ", vm.toString(255 - i))));
+        }
+    }
+
+    function testClzSelectValues() pure public {
+        assertEq(BitOps.clz(0x000F), 252, "CLZ of 0x000F should be 252");
+        assertEq(BitOps.clz(0x00FF), 248, "CLZ of 0x00FF should be 248");
+        assertEq(BitOps.clz(0x0100), 247, "CLZ of 0x0100 should be 247");
+        assertEq(BitOps.clz(0xFFFF), 240, "CLZ of 0xFFFF should be 240");
+        assertEq(BitOps.clz(0x8000), 240, "CLZ of 0x8000 should be 240");
+        assertEq(BitOps.clz(0x80000000), 56*4, "CLZ of 0x80000000 should be 56*4");
+        assertEq(BitOps.clz(0x8FFFFFFF), 56*4, "CLZ of 0x8FFFFFFF should be 56*4");
+        assertEq(BitOps.clz(0x8000000000000000), 48*4, "CLZ of 0x8000000000000000 should be 48*4");
+    }
+}

--- a/contracts/test/Proofs.t.sol
+++ b/contracts/test/Proofs.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {MerkleProof} from "../src/Proofs.sol";
+import {BitOps} from "../src/BitOps.sol";
+import {Hashes} from "../src/Proofs.sol";
+ 
+contract MerkleProofTest is Test {
+
+    function testVerifyEmptyProof() public view {
+        bytes32 root = sha256("hello");
+        bytes32[] memory proof = new bytes32[](0);
+        bool result = MerkleProof.verify(proof, root, root);
+        assertEq(result, true, "Verify should return true");
+    }
+
+    function testVerifyTreeTwoLeaves() public view {
+        bytes32[] memory leaves = generateLeaves(2);
+        bytes32[][] memory tree = buildMerkleTree(leaves);
+        bytes32 root = tree[0][0];
+
+        for (uint i = 0; i < leaves.length; i++) {
+            bytes32[] memory proof = buildProof(tree, i);
+            bool result = MerkleProof.verify(proof, root, leaves[i]);
+            assertEq(result, true, string.concat("Invalid proof for leaf ", vm.toString(i)));
+        }
+    }
+
+    function testVerifyTreeThreeLeaves() public view {
+        bytes32[] memory leaves = generateLeaves(3);
+        bytes32[][] memory tree = buildMerkleTree(leaves);
+        bytes32 root = tree[0][0];
+
+        for (uint i = 0; i < leaves.length; i++) {
+            bytes32[] memory proof = buildProof(tree, i);
+            bool result = MerkleProof.verify(proof, root, leaves[i]);
+            assertEq(result, true, string.concat("Invalid proof for leaf ", vm.toString(i)));
+        }
+    }
+
+
+    function testVerifyTreesManyLeaves() public view {
+        for (uint256 width = 1; width < 100; width++) {
+            bytes32[] memory leaves = generateLeaves(width);
+            bytes32[][] memory tree = buildMerkleTree(leaves);
+            bytes32 root = tree[0][0];
+
+            // Verify proof for each leaf
+            for (uint256 i = 0; i < leaves.length; i++) {
+                bytes32[] memory proof = buildProof(tree, i);
+                bool result = MerkleProof.verify(proof, root, leaves[i]);
+                assertEq(result, true, string.concat("Invalid proof for leaf ", vm.toString(i)));
+            }
+        }
+    }
+
+    ///// Helper functions /////
+
+    function generateLeaves(uint256 count) internal pure returns (bytes32[] memory) {
+        bytes32[] memory result = new bytes32[](count);
+        for (uint256 i = 0; i < count; i++) {
+            result[i] = bytes32(i);
+        }
+        return result;
+    }
+
+    // Builds a merkle tree from an array of leaves.
+    // The tree is an array of arrays of bytes32.
+    // The last array is the leaves, and each prior array is the result of the commutative hash of pairs in the previous array.
+    // An unpaired element is simply copied to the next level.
+    // The first element of the first array is the root.
+    function buildMerkleTree(bytes32[] memory leaves) internal view returns (bytes32[][] memory) {
+        require(leaves.length > 0, "Leaves array must not be empty");
+
+        uint256 levels = 256 - BitOps.clz(leaves.length - 1);
+        bytes32[][] memory tree = new bytes32[][](levels + 1);
+        tree[levels] = leaves;
+
+        for (uint256 i = levels; i > 0; i--) {
+            bytes32[] memory currentLevel = tree[i];
+            uint256 nextLevelSize = (currentLevel.length + 1) / 2;
+            tree[i - 1] = new bytes32[](nextLevelSize);
+
+            for (uint256 j = 0; j < nextLevelSize; j++) {
+                if (2 * j + 1 < currentLevel.length) {
+                    tree[i - 1][j] = Hashes.commutativeHash(currentLevel[2 * j], currentLevel[2 * j + 1]);
+                } else {
+                    tree[i - 1][j] = currentLevel[2 * j];
+                }
+            }
+        }
+
+        return tree;
+    }
+
+    // Gets an inclusion proof from a Merkle tree for a leaf at a given index.
+    // The proof is constructed by traversing up the tree to the root, and the sibling of each node is appended to the proof.
+    // There is no sibling for an unpaired element, so it is not included in the proof, which thus is shorter than the tree height.
+    function buildProof(bytes32[][] memory tree, uint256 index) internal pure returns (bytes32[] memory) {
+        require(index < tree[tree.length - 1].length, "Index out of bounds");
+
+        bytes32[] memory proof = new bytes32[](tree.length - 1);
+        uint256 proofIndex = 0;
+
+        for (uint256 i = tree.length - 1; i > 0; i--) {
+            uint256 levelSize = tree[i].length;
+            uint256 pairIndex = index ^ 1; // XOR with 1 to get the pair index
+
+            if (pairIndex < levelSize) {
+                proof[proofIndex] = tree[i][pairIndex];
+                proofIndex++;
+            }
+
+            index /= 2; // Move to the parent node
+        }
+        // Trim proof to the correct length, from proofIndex.
+        bytes32[] memory trimmedProof = new bytes32[](proofIndex);
+        for (uint256 i = 0; i < proofIndex; i++) {
+            trimmedProof[i] = proof[i];
+        }
+        return trimmedProof;
+    }
+
+    function printTree(bytes32[][] memory tree) internal pure {
+        console.log("Tree:");
+        for (uint i = 0; i < tree.length; i++) {
+            console.log("Level ", i, ":");
+            for (uint j = 0; j < tree[i].length; j++) {
+                console.log(vm.toString(j), vm.toString(tree[i][j]));
+            }
+        }
+        console.log();
+    }
+
+    function printProof(bytes32[] memory proof) internal pure {
+        console.log("Proof: ");
+        for (uint j = 0; j < proof.length; j++) {
+            console.log(vm.toString(j), vm.toString(proof[j]));
+        }
+    }
+}
+
+contract HashesTest is Test {
+    // Tests that the efficient hash function returns the same result as the expected hash function.
+    function testHash() public view {
+        bytes32 a = bytes32(0x0000000000000000000000000000000000000000000000000000000000000000);
+        bytes32 b = bytes32(0x0000000000000000000000000000000000000000000000000000000000000001);
+        verifyHash(a, a);
+        verifyHash(a, b);
+        verifyHash(b, a);
+    }
+
+    function verifyHash(bytes32 a, bytes32 b) internal view {
+        bytes32 expected = expectedHash(a, b);
+        bytes32 result = Hashes.commutativeHash(a, b);
+        assertEq(result, expected, "Hashes.commutativeHash should return the expected hash");
+    }
+
+    // Implements commutative SHA256 hash of pairs via the standard sha256(abi.encode(a, b)).
+    function expectedHash(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        bytes memory payload = a < b ? abi.encodePacked(a, b) : abi.encodePacked(b, a);
+        return sha256(payload);
+    }
+
+}


### PR DESCRIPTION
The proof verification is adapted from OpenZeppelin libraries, with the hash changed to SHA256. The testing code includes building of trees from an array of roots, which we must replicate off-chain.