### PR TITLE
Change Merkle proof scheme to verify leaf position

### DIFF
--- a/contracts/test/Proofs.t.sol
+++ b/contracts/test/Proofs.t.sol
@@ -11,7 +11,7 @@ contract MerkleProofTest is Test {
     function testVerifyEmptyProof() public view {
         bytes32 root = sha256("hello");
         bytes32[] memory proof = new bytes32[](0);
-        bool result = MerkleProof.verify(proof, root, root);
+        bool result = MerkleProof.verify(proof, root, root, 0);
         assertEq(result, true, "Verify should return true");
     }
 
@@ -22,8 +22,8 @@ contract MerkleProofTest is Test {
 
         for (uint i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = buildProof(tree, i);
-            bool result = MerkleProof.verify(proof, root, leaves[i]);
-            assertEq(result, true, string.concat("Invalid proof for leaf ", vm.toString(i)));
+            assertTrue(MerkleProof.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
+            assertFalse(MerkleProof.verify(proof, root, leaves[i], i+1), string.concat("False proof ", vm.toString(i)));
         }
     }
 
@@ -34,14 +34,19 @@ contract MerkleProofTest is Test {
 
         for (uint i = 0; i < leaves.length; i++) {
             bytes32[] memory proof = buildProof(tree, i);
-            bool result = MerkleProof.verify(proof, root, leaves[i]);
-            assertEq(result, true, string.concat("Invalid proof for leaf ", vm.toString(i)));
+            assertTrue(MerkleProof.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
+            // Ensure the proof is invalid for every other index within range
+            for (uint j = 0; j < leaves.length; j++) {
+                if (j != i) {
+                    assertFalse(MerkleProof.verify(proof, root, leaves[i], j));
+                }
+            }
         }
     }
 
 
     function testVerifyTreesManyLeaves() public view {
-        for (uint256 width = 1; width < 100; width++) {
+        for (uint256 width = 4; width < 60; width++) {
             bytes32[] memory leaves = generateLeaves(width);
             bytes32[][] memory tree = buildMerkleTree(leaves);
             bytes32 root = tree[0][0];
@@ -49,8 +54,13 @@ contract MerkleProofTest is Test {
             // Verify proof for each leaf
             for (uint256 i = 0; i < leaves.length; i++) {
                 bytes32[] memory proof = buildProof(tree, i);
-                bool result = MerkleProof.verify(proof, root, leaves[i]);
-                assertEq(result, true, string.concat("Invalid proof for leaf ", vm.toString(i)));
+                assertTrue(MerkleProof.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
+                // Ensure the proof is invalid for every other index within range
+                for (uint j = 0; j < leaves.length; j++) {
+                    if (j != i) {
+                        assertFalse(MerkleProof.verify(proof, root, leaves[i], j));
+                    }
+                }
             }
         }
     }
@@ -68,7 +78,7 @@ contract MerkleProofTest is Test {
     // Builds a merkle tree from an array of leaves.
     // The tree is an array of arrays of bytes32.
     // The last array is the leaves, and each prior array is the result of the commutative hash of pairs in the previous array.
-    // An unpaired element is simply copied to the next level.
+    // An unpaired element is paired with itself to create the value at the next level up.
     // The first element of the first array is the root.
     function buildMerkleTree(bytes32[] memory leaves) internal view returns (bytes32[][] memory) {
         require(leaves.length > 0, "Leaves array must not be empty");
@@ -84,9 +94,10 @@ contract MerkleProofTest is Test {
 
             for (uint256 j = 0; j < nextLevelSize; j++) {
                 if (2 * j + 1 < currentLevel.length) {
-                    tree[i - 1][j] = Hashes.commutativeHash(currentLevel[2 * j], currentLevel[2 * j + 1]);
+                    tree[i - 1][j] = Hashes.orderedHash(currentLevel[2 * j], currentLevel[2 * j + 1]);
                 } else {
-                    tree[i - 1][j] = currentLevel[2 * j];
+                    // Pair final odd node with itself.
+                    tree[i - 1][j] = Hashes.orderedHash(currentLevel[2 * j], currentLevel[2 * j]);
                 }
             }
         }
@@ -96,7 +107,8 @@ contract MerkleProofTest is Test {
 
     // Gets an inclusion proof from a Merkle tree for a leaf at a given index.
     // The proof is constructed by traversing up the tree to the root, and the sibling of each node is appended to the proof.
-    // There is no sibling for an unpaired element, so it is not included in the proof, which thus is shorter than the tree height.
+    // A final unpaired element in any level is paired with itself.
+    // Every proof thus has length equal to the height of the tree minus 1.
     function buildProof(bytes32[][] memory tree, uint256 index) internal pure returns (bytes32[] memory) {
         require(index < tree[tree.length - 1].length, "Index out of bounds");
 
@@ -109,17 +121,14 @@ contract MerkleProofTest is Test {
 
             if (pairIndex < levelSize) {
                 proof[proofIndex] = tree[i][pairIndex];
-                proofIndex++;
+            } else {
+                // Pair final odd node with itself
+                proof[proofIndex] = tree[i][index];
             }
-
+            proofIndex++;
             index /= 2; // Move to the parent node
         }
-        // Trim proof to the correct length, from proofIndex.
-        bytes32[] memory trimmedProof = new bytes32[](proofIndex);
-        for (uint256 i = 0; i < proofIndex; i++) {
-            trimmedProof[i] = proof[i];
-        }
-        return trimmedProof;
+        return proof;
     }
 
     function printTree(bytes32[][] memory tree) internal pure {
@@ -153,13 +162,13 @@ contract HashesTest is Test {
 
     function verifyHash(bytes32 a, bytes32 b) internal view {
         bytes32 expected = expectedHash(a, b);
-        bytes32 result = Hashes.commutativeHash(a, b);
+        bytes32 result = Hashes.orderedHash(a, b);
         assertEq(result, expected, "Hashes.commutativeHash should return the expected hash");
     }
 
     // Implements commutative SHA256 hash of pairs via the standard sha256(abi.encode(a, b)).
     function expectedHash(bytes32 a, bytes32 b) internal pure returns (bytes32) {
-        bytes memory payload = a < b ? abi.encodePacked(a, b) : abi.encodePacked(b, a);
+        bytes memory payload = abi.encodePacked(a, b);
         return sha256(payload);
     }
 


### PR DESCRIPTION
We need to verify the position of a leaf and a protocol-determined offset, not any provider-chosen leaf.