### PR TITLE
Implement SHA254 hashing for the merkle tree

### DIFF
--- a/contracts/src/Proofs.sol
+++ b/contracts/src/Proofs.sol
@@ -83,12 +83,12 @@ library MerkleProof {
 library Hashes {
     /** Order-dependent hash of pair of bytes32. */
     function orderedHash(bytes32 a, bytes32 b) internal view returns (bytes32) {
-        return _efficientSHA256(a, b);
+        return _efficientSHA254(a, b);
     }
 
 
-    /** Implementation of sha256(abi.encode(a, b)) that doesn't allocate or expand memory. */
-    function _efficientSHA256(bytes32 a, bytes32 b) private view returns (bytes32 value) {
+    /** Implementation equivalent to using sha256(abi.encode(a, b)) that doesn't allocate or expand memory. */
+    function _efficientSHA254(bytes32 a, bytes32 b) private view returns (bytes32 value) {
         assembly ("memory-safe") {
             mstore(0x00, a)
             mstore(0x20, b)
@@ -99,6 +99,12 @@ library Hashes {
             }
             
             value := mload(0x00)
+            // SHA254 hash for compatibility with Filecoin piece commitments.
+            // "The Sha254 functions are identical to Sha256 except that the last two bits of the Sha256 256-bit digest are zeroed out."
+            // The bytes of uint256 are arranged in big-endian order, MSB first in memory.
+            // The bits in each byte are arranged in little-endian order.
+            // Thus, the "last two bits" are the first two bits of the last byte.
+            value := and(value, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3F)
         }
     }
 }

--- a/contracts/src/Proofs.sol
+++ b/contracts/src/Proofs.sol
@@ -81,11 +81,16 @@ library MerkleProof {
 }
 
 library Hashes {
+    // "The Sha254 functions are identical to Sha256 except that the last two bits of the Sha256 256-bit digest are zeroed out."
+    // The bytes of uint256 are arranged in big-endian order, MSB first in memory.
+    // The bits in each byte are arranged in little-endian order.
+    // Thus, the "last two bits" are the first two bits of the last byte.
+    uint256 constant SHA254_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3F;
+
     /** Order-dependent hash of pair of bytes32. */
     function orderedHash(bytes32 a, bytes32 b) internal view returns (bytes32) {
         return _efficientSHA254(a, b);
     }
-
 
     /** Implementation equivalent to using sha256(abi.encode(a, b)) that doesn't allocate or expand memory. */
     function _efficientSHA254(bytes32 a, bytes32 b) private view returns (bytes32 value) {
@@ -100,11 +105,7 @@ library Hashes {
             
             value := mload(0x00)
             // SHA254 hash for compatibility with Filecoin piece commitments.
-            // "The Sha254 functions are identical to Sha256 except that the last two bits of the Sha256 256-bit digest are zeroed out."
-            // The bytes of uint256 are arranged in big-endian order, MSB first in memory.
-            // The bits in each byte are arranged in little-endian order.
-            // Thus, the "last two bits" are the first two bits of the last byte.
-            value := and(value, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3F)
+            value := and(value, SHA254_MASK)
         }
     }
 }

--- a/contracts/test/Proofs.t.sol
+++ b/contracts/test/Proofs.t.sol
@@ -197,7 +197,7 @@ contract HashesTest is Test {
     function expectedHash(bytes32 a, bytes32 b) internal pure returns (bytes32) {
         bytes memory payload = abi.encodePacked(a, b);
         bytes32 digest = sha256(payload);
-        digest = bytes32((uint256(digest) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3F));
+        digest = bytes32((uint256(digest) & Hashes.SHA254_MASK));
         return digest;
     }
 }

--- a/contracts/test/Proofs.t.sol
+++ b/contracts/test/Proofs.t.sol
@@ -44,7 +44,6 @@ contract MerkleProofTest is Test {
         }
     }
 
-
     function testVerifyTreesManyLeaves() public view {
         for (uint256 width = 4; width < 60; width++) {
             bytes32[] memory leaves = generateLeaves(width);
@@ -166,10 +165,11 @@ contract HashesTest is Test {
         assertEq(result, expected, "Hashes.commutativeHash should return the expected hash");
     }
 
-    // Implements commutative SHA256 hash of pairs via the standard sha256(abi.encode(a, b)).
+    // Implements SHA254 hash of pairs via the standard sha256(abi.encode(a, b)).
     function expectedHash(bytes32 a, bytes32 b) internal pure returns (bytes32) {
         bytes memory payload = abi.encodePacked(a, b);
-        return sha256(payload);
+        bytes32 digest = sha256(payload);
+        digest = bytes32((uint256(digest) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3F));
+        return digest;
     }
-
 }


### PR DESCRIPTION
This is only part of Filecoin piece CID compatibility, but should do the job for power-of-two data sizes.