### PR TITLE
Record next challenge epoch. Extract CID to library.

### DIFF
--- a/contracts/src/Cids.sol
+++ b/contracts/src/Cids.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+library Cids {
+    // TODO PERF: https://github.com/FILCAT/pdp/issues/16#issuecomment-2329836995 
+    struct Cid {
+        bytes data;
+    }
+
+    function digestFromCid(Cid memory cid) public pure returns (bytes32) {
+        require(cid.data.length >= 32, "Cid data is too short");
+        // bytes memory dataSlice = new bytes(32);
+        // Assembly version of
+        // for (uint i = 0; i < 32; i++) {
+        //     dataSlice[i] = cid.data[cid.data.length - 32 + i];
+        // }
+        // return bytes32(dataSlice);   
+        assembly {
+            // Allocate memory for the data slice.
+            // Set dataSclice to the next 32-byte aligned location after the free memory pointer (at 0x40).
+            let dataSlice := add(mload(0x40), 0x20)
+            // Update free memory pointer to next slot after dataSlice.
+            mstore(0x40, add(dataSlice, 0x20))
+
+            // Copy the last 32 bytes from cid.data to dataSlice.
+            // Load the length of cid.data (length is the first word in an array memory layout).
+            let dataLength := mload(mload(cid))
+            // Calculate starting position of the last 32 bytes in cid.data.
+            let dataStart := add(mload(cid), sub(dataLength, 32))
+            // Copy 32 bytes (one word) from dataStart into dataSlice.
+            mstore(dataSlice, mload(dataStart))
+
+            // Return the 32-byte slice as bytes32.
+            // Store the data slice at 0x0 (an unused memory word).
+            mstore(0x0, mload(dataSlice))
+            // Return the 32 bytes at Ox0 as a bytes32.
+            return(0x0, 0x20)
+        }
+    }
+}


### PR DESCRIPTION
This is a prefactor extracted from my work implementing `provePosession`. In addition to adding the challenge epoch, I realised there is insufficient testing for the basic logic around adding and removing pieces, and resolving all this was going to balloon the PR adding proving (for which the testing will be quite involved).

I haven't added all the necessary tests here, but it would be great @ZenGround0 if you could follow on from this and fill out those workflow tests. 