### PR TITLE
Implement proof of possesion

### DIFF
--- a/contracts/src/Cids.sol
+++ b/contracts/src/Cids.sol
@@ -7,34 +7,49 @@ library Cids {
         bytes data;
     }
 
+    // Returns the last 32 bytes of a CID payload as a bytes32.
     function digestFromCid(Cid memory cid) public pure returns (bytes32) {
         require(cid.data.length >= 32, "Cid data is too short");
-        // bytes memory dataSlice = new bytes(32);
-        // Assembly version of
-        // for (uint i = 0; i < 32; i++) {
-        //     dataSlice[i] = cid.data[cid.data.length - 32 + i];
-        // }
-        // return bytes32(dataSlice);   
-        assembly {
-            // Allocate memory for the data slice.
-            // Set dataSclice to the next 32-byte aligned location after the free memory pointer (at 0x40).
-            let dataSlice := add(mload(0x40), 0x20)
-            // Update free memory pointer to next slot after dataSlice.
-            mstore(0x40, add(dataSlice, 0x20))
-
-            // Copy the last 32 bytes from cid.data to dataSlice.
-            // Load the length of cid.data (length is the first word in an array memory layout).
-            let dataLength := mload(mload(cid))
-            // Calculate starting position of the last 32 bytes in cid.data.
-            let dataStart := add(mload(cid), sub(dataLength, 32))
-            // Copy 32 bytes (one word) from dataStart into dataSlice.
-            mstore(dataSlice, mload(dataStart))
-
-            // Return the 32-byte slice as bytes32.
-            // Store the data slice at 0x0 (an unused memory word).
-            mstore(0x0, mload(dataSlice))
-            // Return the 32 bytes at Ox0 as a bytes32.
-            return(0x0, 0x20)
+        bytes memory dataSlice = new bytes(32);
+        for (uint i = 0; i < 32; i++) {
+            dataSlice[i] = cid.data[cid.data.length - 32 + i];
         }
+        return bytes32(dataSlice);   
+        // The above can almost certainly be optimised in assembly.
+        // However, the below assembly behaves differently and is beyond my ability to resolve.
+        // assembly {
+        //     // Allocate memory for the data slice.
+        //     // Set dataSclice to the next 32-byte aligned location after the free memory pointer (at 0x40).
+        //     let dataSlice := add(mload(0x40), 0x20)
+        //     // Update free memory pointer to next slot after dataSlice.
+        //     mstore(0x40, add(dataSlice, 0x20))
+
+        //     // Copy the last 32 bytes from cid.data to dataSlice.
+        //     // Load the length of cid.data (length is the first word in an array memory layout).
+        //     let dataLength := mload(mload(cid))
+        //     // Calculate starting position of the last 32 bytes in cid.data.
+        //     let dataStart := add(mload(cid), sub(dataLength, 32))
+        //     // Copy 32 bytes (one word) from dataStart into dataSlice.
+        //     mstore(dataSlice, mload(dataStart))
+
+        //     // Return the 32-byte slice as bytes32.
+        //     // Store the data slice at 0x0 (an unused memory word).
+        //     mstore(0x0, mload(dataSlice))
+        //     // Return the 32 bytes at Ox0 as a bytes32.
+        //     return(0x0, 0x20)
+        // }
+    }
+
+    // Makes a CID from a prefix and a digest.
+    // The prefix doesn't matter to these contracts, which only inspect the last 32 bytes (the hash digest).
+    function cidFromDigest(bytes memory prefix, bytes32 digest) internal pure returns (Cids.Cid memory) {
+        bytes memory byteArray = new bytes(prefix.length + 32);
+        for (uint256 i = 0; i < prefix.length; i++) {
+            byteArray[i] = prefix[i];
+        }
+        for (uint256 i = 0; i < 32; i++) {
+            byteArray[i+prefix.length] = bytes1(digest << (i * 8));
+        }
+        return Cids.Cid(byteArray);
     }
 }

--- a/contracts/src/Cids.sol
+++ b/contracts/src/Cids.sol
@@ -15,6 +15,7 @@ library Cids {
             dataSlice[i] = cid.data[cid.data.length - 32 + i];
         }
         return bytes32(dataSlice);   
+        // See https://github.com/FILCAT/pdp/issues/15 performance measurement and improvement
         // The above can almost certainly be optimised in assembly.
         // However, the below assembly behaves differently and is beyond my ability to resolve.
         // assembly {

--- a/contracts/src/PDPService.sol
+++ b/contracts/src/PDPService.sol
@@ -304,6 +304,7 @@ contract PDPService {
     function provePossession(uint256 setId, Proof[] calldata proofs) public {
         uint256 challengeEpoch = nextChallengeEpoch[setId];
         require(block.number >= challengeEpoch, "premature proof");
+        require(proofs.length > 0, "empty proof");
 
         // TODO: fetch proper seed from chain randomness, https://github.com/FILCAT/pdp/issues/44
         uint256 seed = challengeEpoch;

--- a/contracts/src/PDPService.sol
+++ b/contracts/src/PDPService.sol
@@ -305,7 +305,7 @@ contract PDPService {
         uint256 challengeEpoch = nextChallengeEpoch[setId];
         require(block.number >= challengeEpoch, "premature proof");
 
-        // TODO: fetch proper seed from chain randomness
+        // TODO: fetch proper seed from chain randomness, https://github.com/FILCAT/pdp/issues/44
         uint256 seed = challengeEpoch;
         uint256 leafCount = getProofSetLeafCount(setId);
         uint256 sumTreeTop = 256 - BitOps.clz(nextRootId[setId]);
@@ -324,7 +324,6 @@ contract PDPService {
 
         // Set the next challenge epoch.
         nextChallengeEpoch[setId] = block.number + challengeFinality; 
-        // TODO: record the successful proof somewhere.
     }
 
     /* Sum tree functions */

--- a/contracts/src/Proofs.sol
+++ b/contracts/src/Proofs.sol
@@ -150,7 +150,7 @@ library MerkleVerify {
 library MerkleProve {
     // Builds a merkle tree from an array of leaves.
     // The tree is an array of arrays of bytes32.
-    // The last array is the leaves, and each prior array is the result of the commutative hash of pairs in the previous array.
+    // The last array is the leaves, and each prior array is the result of the hash of pairs in the previous array.
     // An unpaired element is paired with the root of a tree of the same height with zero leaves.
     // The first element of the first array is the root.
     function buildTree(bytes32[] memory leaves) internal view returns (bytes32[][] memory) {

--- a/contracts/src/Proofs.sol
+++ b/contracts/src/Proofs.sol
@@ -153,7 +153,7 @@ library MerkleProve {
     // The last array is the leaves, and each prior array is the result of the commutative hash of pairs in the previous array.
     // An unpaired element is paired with the root of a tree of the same height with zero leaves.
     // The first element of the first array is the root.
-    function buildMerkleTree(bytes32[] memory leaves) internal view returns (bytes32[][] memory) {
+    function buildTree(bytes32[] memory leaves) internal view returns (bytes32[][] memory) {
         require(leaves.length > 0, "Leaves array must not be empty");
 
         uint256 levels = 256 - BitOps.clz(leaves.length - 1);

--- a/contracts/test/Cids.t.sol
+++ b/contracts/test/Cids.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Cids} from "../src/Cids.sol";
+
+contract CidsTest is Test {
+    function testDigestRoundTrip() pure public {
+        bytes memory prefix = "prefix";
+        bytes32 digest = 0xbeadcafefacedeedfeedbabedeadbeefbeadcafefacedeedfeedbabedeadbeef;
+        Cids.Cid memory c = Cids.cidFromDigest(prefix, digest);
+        assertEq(c.data.length, 6 + 32);
+        bytes32 foundDigest = Cids.digestFromCid(c);
+        assertEq(foundDigest, digest);
+    }
+}

--- a/contracts/test/ProofUtil.sol
+++ b/contracts/test/ProofUtil.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Cids} from "../src/Cids.sol";
+import {MerkleVerify, Hashes} from "../src/Proofs.sol";
+
+// Methods for committing to data and generating proofs.
+// These are only used in tests (which verify proofs).
+// These functions provide a spec for the operations which providers should perform off-chain.
+library ProofUtil {
+    /** Generates an array of leaves with distinct values. */
+    function generateLeaves(uint256 count) internal pure returns (bytes32[] memory) {
+        bytes32[] memory result = new bytes32[](count);
+        for (uint256 i = 0; i < count; i++) {
+            result[i] = bytes32(i);
+        }
+        return result;
+    }
+
+}

--- a/contracts/test/ProofUtil.sol
+++ b/contracts/test/ProofUtil.sol
@@ -2,12 +2,19 @@
 pragma solidity ^0.8.20;
 
 import {Cids} from "../src/Cids.sol";
-import {MerkleVerify, Hashes} from "../src/Proofs.sol";
+import {MerkleProve, MerkleVerify, Hashes} from "../src/Proofs.sol";
 
 // Methods for committing to data and generating proofs.
 // These are only used in tests (which verify proofs).
 // These functions provide a spec for the operations which providers should perform off-chain.
 library ProofUtil {
+    /** Builds a Merkle tree over data that is a sequence of distinct leaf values. */
+    function makeTree(uint leafCount) internal view returns (bytes32[][] memory) {
+        bytes32[] memory data = generateLeaves(leafCount);
+        bytes32[][] memory tree = MerkleProve.buildTree(data);
+        return tree;
+    }
+
     /** Generates an array of leaves with distinct values. */
     function generateLeaves(uint256 count) internal pure returns (bytes32[] memory) {
         bytes32[] memory result = new bytes32[](count);

--- a/contracts/test/Proofs.t.sol
+++ b/contracts/test/Proofs.t.sol
@@ -2,43 +2,43 @@
 pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";
-import {MerkleProof} from "../src/Proofs.sol";
 import {BitOps} from "../src/BitOps.sol";
-import {Hashes} from "../src/Proofs.sol";
+import {Hashes, MerkleProve, MerkleVerify} from "../src/Proofs.sol";
+import {ProofUtil} from "./ProofUtil.sol";
  
-contract MerkleProofTest is Test {
+contract MerkleProveTest is Test {
 
     function testVerifyEmptyProof() public view {
         bytes32 root = sha256("hello");
         bytes32[] memory proof = new bytes32[](0);
-        bool result = MerkleProof.verify(proof, root, root, 0);
+        bool result = MerkleVerify.verify(proof, root, root, 0);
         assertEq(result, true, "Verify should return true");
     }
 
     function testVerifyTreeTwoLeaves() public view {
-        bytes32[] memory leaves = generateLeaves(2);
-        bytes32[][] memory tree = buildMerkleTree(leaves);
+        bytes32[] memory leaves = ProofUtil.generateLeaves(2);
+        bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
         bytes32 root = tree[0][0];
 
         for (uint i = 0; i < leaves.length; i++) {
-            bytes32[] memory proof = buildProof(tree, i);
-            assertTrue(MerkleProof.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
-            assertFalse(MerkleProof.verify(proof, root, leaves[i], i+1), string.concat("False proof ", vm.toString(i)));
+            bytes32[] memory proof = MerkleProve.buildProof(tree, i);
+            assertTrue(MerkleVerify.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
+            assertFalse(MerkleVerify.verify(proof, root, leaves[i], i+1), string.concat("False proof ", vm.toString(i)));
         }
     }
 
     function testVerifyTreeThreeLeaves() public view {
-        bytes32[] memory leaves = generateLeaves(3);
-        bytes32[][] memory tree = buildMerkleTree(leaves);
+        bytes32[] memory leaves = ProofUtil.generateLeaves(3);
+        bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
         bytes32 root = tree[0][0];
 
         for (uint i = 0; i < leaves.length; i++) {
-            bytes32[] memory proof = buildProof(tree, i);
-            assertTrue(MerkleProof.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
+            bytes32[] memory proof = MerkleProve.buildProof(tree, i);
+            assertTrue(MerkleVerify.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
             // Ensure the proof is invalid for every other index within range
             for (uint j = 0; j < leaves.length; j++) {
                 if (j != i) {
-                    assertFalse(MerkleProof.verify(proof, root, leaves[i], j));
+                    assertFalse(MerkleVerify.verify(proof, root, leaves[i], j));
                 }
             }
         }
@@ -46,18 +46,18 @@ contract MerkleProofTest is Test {
 
     function testVerifyTreesManyLeaves() public view {
         for (uint256 width = 4; width < 60; width++) {
-            bytes32[] memory leaves = generateLeaves(width);
-            bytes32[][] memory tree = buildMerkleTree(leaves);
+            bytes32[] memory leaves = ProofUtil.generateLeaves(width);
+            bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
             bytes32 root = tree[0][0];
 
             // Verify proof for each leaf
             for (uint256 i = 0; i < leaves.length; i++) {
-                bytes32[] memory proof = buildProof(tree, i);
-                assertTrue(MerkleProof.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
+                bytes32[] memory proof = MerkleProve.buildProof(tree, i);
+                assertTrue(MerkleVerify.verify(proof, root, leaves[i], i), string.concat("Invalid proof ", vm.toString(i)));
                 // Ensure the proof is invalid for every other index within range
                 for (uint j = 0; j < leaves.length; j++) {
                     if (j != i) {
-                        assertFalse(MerkleProof.verify(proof, root, leaves[i], j));
+                        assertFalse(MerkleVerify.verify(proof, root, leaves[i], j));
                     }
                 }
             }
@@ -79,7 +79,7 @@ contract MerkleProofTest is Test {
         // Build payload of of 2KiB of zeros, packed into bytes32 words
         bytes32[] memory payload = new bytes32[](2048 / 32);
 
-        bytes32[][] memory tree = buildMerkleTree(payload);
+        bytes32[][] memory tree = MerkleProve.buildMerkleTree(payload);
         assertEq(tree[0][0], expected);
     }
 
@@ -91,36 +91,36 @@ contract MerkleProofTest is Test {
         //     console.log(vm.toString(i), vm.toString(zeroRoots[i]));
         // }
         for (uint height = 0; height <= 50; height++) {
-            assertEq(MerkleProof.zeroRoot(height), expected[height]);
+            assertEq(MerkleVerify.zeroRoot(height), expected[height]);
         }
     }
 
     // Tests some zero roots against known values for Filecoin sector sizes.
     // The target digets are copied directly from built-in actors code.
     function testZeroRootFilecoinEquivalence() public pure {
-        assertEq(MerkleProof.zeroRoot(0), 0);
+        assertEq(MerkleVerify.zeroRoot(0), 0);
         // 2 KiB / 32 = 64 leaves = 2^6
-        assertEq(MerkleProof.zeroRoot(6), loadDigest([
+        assertEq(MerkleVerify.zeroRoot(6), loadDigest([
             252, 126, 146, 130, 150, 229, 22, 250, 173, 233, 134, 178, 143, 146, 212, 74, 79, 36, 185,
             53, 72, 82, 35, 55, 106, 121, 144, 39, 188, 24, 248, 51
         ]));
         // 8 MiB = 256Ki leaves = 2^8 * 2^10
-        assertEq(MerkleProof.zeroRoot(18), loadDigest([
+        assertEq(MerkleVerify.zeroRoot(18), loadDigest([
             101, 242, 158, 93, 152, 210, 70, 195, 139, 56, 140, 252, 6, 219, 31, 107, 2, 19, 3, 197,
             162, 137, 0, 11, 220, 232, 50, 169, 195, 236, 66, 28
         ]));
         // 512 MiB = 16Mi leaves = 2^4 * 2^20
-        assertEq(MerkleProof.zeroRoot(24), loadDigest([
+        assertEq(MerkleVerify.zeroRoot(24), loadDigest([
             57, 86, 14, 123, 19, 169, 59, 7, 162, 67, 253, 39, 32, 255, 167, 203, 62, 29, 46, 80, 90,
             179, 98, 158, 121, 244, 99, 19, 81, 44, 218, 6
         ]));
         // 32 GiB = 1Gi leaves = 2^30
-        assertEq(MerkleProof.zeroRoot(30), loadDigest([
+        assertEq(MerkleVerify.zeroRoot(30), loadDigest([
             7, 126, 95, 222, 53, 197, 10, 147, 3, 165, 80, 9, 227, 73, 138, 78, 190, 223, 243, 156, 66,
             183, 16, 183, 48, 216, 236, 122, 199, 175, 166, 62
         ]));
         // 64 GiB = 2 * 1Gi leaves = 2^1 * 2^30
-        assertEq(MerkleProof.zeroRoot(31), loadDigest([
+        assertEq(MerkleVerify.zeroRoot(31), loadDigest([
             230, 64, 5, 166, 191, 227, 119, 121, 83, 184, 173, 110, 249, 63, 15, 202, 16, 73, 178, 4,
             22, 84, 242, 164, 17, 247, 112, 39, 153, 206, 206, 2
         ]));
@@ -130,77 +130,13 @@ contract MerkleProofTest is Test {
     function testZeroTreeFilecoinEquivalence() public view {
         for (uint i = 1; i <= 16; i++) {
             bytes32[] memory leaves = new bytes32[](i);
-            bytes32[][] memory tree = buildMerkleTree(leaves);
+            bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
             uint256 height = 256 - BitOps.clz(i - 1);
-            assertEq(tree[0][0], MerkleProof.zeroRoot(height));
+            assertEq(tree[0][0], MerkleVerify.zeroRoot(height));
         }
     }
 
     ///// Helper functions /////
-
-    function generateLeaves(uint256 count) internal pure returns (bytes32[] memory) {
-        bytes32[] memory result = new bytes32[](count);
-        for (uint256 i = 0; i < count; i++) {
-            result[i] = bytes32(i);
-        }
-        return result;
-    }
-
-    // Builds a merkle tree from an array of leaves.
-    // The tree is an array of arrays of bytes32.
-    // The last array is the leaves, and each prior array is the result of the commutative hash of pairs in the previous array.
-    // An unpaired element is paired with the root of a tree of the same height with zero leaves.
-    // The first element of the first array is the root.
-    function buildMerkleTree(bytes32[] memory leaves) internal view returns (bytes32[][] memory) {
-        require(leaves.length > 0, "Leaves array must not be empty");
-
-        uint256 levels = 256 - BitOps.clz(leaves.length - 1);
-        bytes32[][] memory tree = new bytes32[][](levels + 1);
-        tree[levels] = leaves;
-
-        for (uint256 i = levels; i > 0; i--) {
-            bytes32[] memory currentLevel = tree[i];
-            uint256 nextLevelSize = (currentLevel.length + 1) / 2;
-            tree[i - 1] = new bytes32[](nextLevelSize);
-
-            for (uint256 j = 0; j < nextLevelSize; j++) {
-                if (2 * j + 1 < currentLevel.length) {
-                    tree[i - 1][j] = Hashes.orderedHash(currentLevel[2 * j], currentLevel[2 * j + 1]);
-                } else {
-                    // Pair final odd node with a zero-tree of same height.
-                    tree[i - 1][j] = Hashes.orderedHash(currentLevel[2 * j], MerkleProof.zeroRoot(levels - i));
-                }
-            }
-        }
-
-        return tree;
-    }
-
-    // Gets an inclusion proof from a Merkle tree for a leaf at a given index.
-    // The proof is constructed by traversing up the tree to the root, and the sibling of each node is appended to the proof.
-    // A final unpaired element in any level is paired with itself.
-    // Every proof thus has length equal to the height of the tree minus 1.
-    function buildProof(bytes32[][] memory tree, uint256 index) internal pure returns (bytes32[] memory) {
-        require(index < tree[tree.length - 1].length, "Index out of bounds");
-
-        bytes32[] memory proof = new bytes32[](tree.length - 1);
-        uint256 proofIndex = 0;
-
-        for (uint256 i = tree.length - 1; i > 0; i--) {
-            uint256 levelSize = tree[i].length;
-            uint256 pairIndex = index ^ 1; // XOR with 1 to get the pair index
-
-            if (pairIndex < levelSize) {
-                proof[proofIndex] = tree[i][pairIndex];
-            } else {
-                // Pair final odd node with zero-tree of same height.
-                proof[proofIndex] = MerkleProof.zeroRoot(tree.length - 1 - i);
-            }
-            proofIndex++;
-            index /= 2; // Move to the parent node
-        }
-        return proof;
-    }
 
     // Returns an array of Merkle tree roots committing to all-zero data of increasing tree heights.
     // The first entry is zero.

--- a/contracts/test/Proofs.t.sol
+++ b/contracts/test/Proofs.t.sol
@@ -17,7 +17,7 @@ contract MerkleProveTest is Test {
 
     function testVerifyTreeTwoLeaves() public view {
         bytes32[] memory leaves = ProofUtil.generateLeaves(2);
-        bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
+        bytes32[][] memory tree = MerkleProve.buildTree(leaves);
         bytes32 root = tree[0][0];
 
         for (uint i = 0; i < leaves.length; i++) {
@@ -29,7 +29,7 @@ contract MerkleProveTest is Test {
 
     function testVerifyTreeThreeLeaves() public view {
         bytes32[] memory leaves = ProofUtil.generateLeaves(3);
-        bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
+        bytes32[][] memory tree = MerkleProve.buildTree(leaves);
         bytes32 root = tree[0][0];
 
         for (uint i = 0; i < leaves.length; i++) {
@@ -47,7 +47,7 @@ contract MerkleProveTest is Test {
     function testVerifyTreesManyLeaves() public view {
         for (uint256 width = 4; width < 60; width++) {
             bytes32[] memory leaves = ProofUtil.generateLeaves(width);
-            bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
+            bytes32[][] memory tree = MerkleProve.buildTree(leaves);
             bytes32 root = tree[0][0];
 
             // Verify proof for each leaf
@@ -79,7 +79,7 @@ contract MerkleProveTest is Test {
         // Build payload of of 2KiB of zeros, packed into bytes32 words
         bytes32[] memory payload = new bytes32[](2048 / 32);
 
-        bytes32[][] memory tree = MerkleProve.buildMerkleTree(payload);
+        bytes32[][] memory tree = MerkleProve.buildTree(payload);
         assertEq(tree[0][0], expected);
     }
 
@@ -130,7 +130,7 @@ contract MerkleProveTest is Test {
     function testZeroTreeFilecoinEquivalence() public view {
         for (uint i = 1; i <= 16; i++) {
             bytes32[] memory leaves = new bytes32[](i);
-            bytes32[][] memory tree = MerkleProve.buildMerkleTree(leaves);
+            bytes32[][] memory tree = MerkleProve.buildTree(leaves);
             uint256 height = 256 - BitOps.clz(i - 1);
             assertEq(tree[0][0], MerkleVerify.zeroRoot(height));
         }


### PR DESCRIPTION
Implemented PDPService.provePosession method, with tests.

At present, uses the challenge epoch itself as the random seed rather than fetching chain randomness from that epoch (see #44).

I moved the Merkle tree and proof building code alongside the verification code since now its needed from multiple test files. The compiler should strip un-called functions from these libraries when deploying.

Closes #9. Closes #10.