### PR TITLE
Integrate record keeper

### DIFF
--- a/contracts/src/Cids.sol
+++ b/contracts/src/Cids.sol
@@ -8,7 +8,7 @@ library Cids {
     }
 
     // Returns the last 32 bytes of a CID payload as a bytes32.
-    function digestFromCid(Cid memory cid) public pure returns (bytes32) {
+    function digestFromCid(Cid memory cid) internal pure returns (bytes32) {
         require(cid.data.length >= 32, "Cid data is too short");
         bytes memory dataSlice = new bytes(32);
         for (uint i = 0; i < 32; i++) {

--- a/contracts/src/PDPRecordKeeper.sol
+++ b/contracts/src/PDPRecordKeeper.sol
@@ -11,6 +11,7 @@ contract PDPRecordKeeper {
 
     // Enum to represent different types of operations
     enum OperationType {
+        NONE,
         CREATE,
         ADD,
         REMOVE,

--- a/contracts/src/PDPService.sol
+++ b/contracts/src/PDPService.sol
@@ -166,12 +166,13 @@ contract PDPService {
         }
 
         require(proofSetOwner[setId] == msg.sender, "Only the owner can delete proof sets");
-
+        uint256 deletedLeafCount = proofSetLeafCount[setId];
         proofSetLeafCount[setId] = 0;
         proofSetOwner[setId] = address(0);
         nextChallengeEpoch[setId] = 0;
 
-        _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.DELETE, bytes(""));
+        bytes memory extraData = abi.encode(deletedLeafCount);
+        _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.DELETE, extraData);
     }
 
     // Struct for tracking root data
@@ -240,7 +241,7 @@ contract PDPService {
             nextChallengeEpoch[setId] = 0;
         }
 
-        bytes memory extraData = abi.encode(rootIds);
+        bytes memory extraData = abi.encode(totalDelta, rootIds);
         _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.REMOVE, extraData);
         return totalDelta;
     }
@@ -410,6 +411,7 @@ contract PDPService {
 
     /* Record keeper functions */
     function _addRecord(uint256 proofSetId, address recordKeeper, PDPRecordKeeper.OperationType operationType, bytes memory extraData) internal {
+        require(address(recordKeeper) != address(0), "Record keeper must be set");
         PDPRecordKeeper(recordKeeper).addRecord(proofSetId, uint64(block.number), operationType, extraData);
     }
 

--- a/contracts/src/PDPService.sol
+++ b/contracts/src/PDPService.sol
@@ -343,7 +343,7 @@ contract PDPService {
 
         // Set the next challenge epoch.
         nextChallengeEpoch[setId] = block.number + challengeFinality; 
-        bytes memory extraData = abi.encode(seed);
+        bytes memory extraData = abi.encode(proofSetLeafCount[setId], seed);
         _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.PROVE_POSSESSION, extraData);
     }
 

--- a/contracts/src/PDPService.sol
+++ b/contracts/src/PDPService.sol
@@ -154,7 +154,8 @@ contract PDPService {
         proofSetOwner[setId] = msg.sender;
         proofSetRecordKeeper[setId] = recordKeeper;
 
-        _addRecord(setId, recordKeeper, PDPRecordKeeper.OperationType.CREATE, bytes(""));
+        bytes memory extraData = abi.encode(msg.sender);
+        _addRecord(setId, recordKeeper, PDPRecordKeeper.OperationType.CREATE, extraData);
         return setId;
     }
 
@@ -194,7 +195,7 @@ contract PDPService {
             nextChallengeEpoch[setId] = block.number + challengeFinality; 
         }
 
-        bytes memory extraData = abi.encode(rootData.length, firstAdded, rootData);
+        bytes memory extraData = abi.encode(firstAdded, rootData);
         _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.ADD, extraData);
         return firstAdded;
     }
@@ -239,7 +240,7 @@ contract PDPService {
             nextChallengeEpoch[setId] = 0;
         }
 
-        bytes memory extraData = abi.encode(rootIds.length, totalDelta, rootIds);
+        bytes memory extraData = abi.encode(rootIds);
         _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.REMOVE, extraData);
         return totalDelta;
     }
@@ -326,6 +327,7 @@ contract PDPService {
         uint256 leafCount = getProofSetLeafCount(setId);
         uint256 sumTreeTop = 256 - BitOps.clz(nextRootId[setId]);
 
+
         for (uint64 i = 0; i < proofs.length; i++) {
             // Hash (SHA3) the seed,  proof set id, and proof index to create challenge.
             bytes memory payload = abi.encodePacked(seed, setId, i);
@@ -340,10 +342,8 @@ contract PDPService {
 
         // Set the next challenge epoch.
         nextChallengeEpoch[setId] = block.number + challengeFinality; 
-        // TODO add in call to record keeper on successful proof 
-        // we should pass in the rootIds that were challenged
-        // bytes memory extraData = abi.encode(provenRootIds);
-        //_addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.PROVE_POSSESSION, extraData);
+        bytes memory extraData = abi.encode(seed);
+        _addRecord(setId, proofSetRecordKeeper[setId], PDPRecordKeeper.OperationType.PROVE_POSSESSION, extraData);
     }
 
     /* Sum tree functions */

--- a/contracts/test/PDPService.t.sol
+++ b/contracts/test/PDPService.t.sol
@@ -961,7 +961,7 @@ contract RecordKeeperHelper is Test {
             require(rootIds.length > 0, "REMOVE: rootIds should not be empty");
             require(totalDelta > 0, "REMOVE: totalDelta should be > 0");
         } else if (operationType == PDPRecordKeeper.OperationType.PROVE_POSSESSION) {
-            abi.decode(extraData, (uint256));
+            abi.decode(extraData, (uint256, uint256));
         } else if (operationType == PDPRecordKeeper.OperationType.DELETE) {
             abi.decode(extraData, (uint256));
         } else {

--- a/contracts/test/PDPService.t.sol
+++ b/contracts/test/PDPService.t.sol
@@ -374,7 +374,7 @@ contract PDPServiceProofTest is Test {
         recordAssert = new RecordKeeperHelper(address(recordKeeper));
     }
 
-    function tearDown() public {
+    function tearDown() public view {
         recordAssert.assertAllRecords();
     }
 
@@ -957,12 +957,13 @@ contract RecordKeeperHelper is Test {
         } else if (operationType == PDPRecordKeeper.OperationType.ADD) {
             abi.decode(extraData, (uint256,PDPService.RootData[]));
         } else if (operationType == PDPRecordKeeper.OperationType.REMOVE) {
-            (uint256[] memory rootIds) = abi.decode(extraData, (uint256[]));
+            (uint256 totalDelta, uint256[] memory rootIds) = abi.decode(extraData, (uint256, uint256[]));
             require(rootIds.length > 0, "REMOVE: rootIds should not be empty");
+            require(totalDelta > 0, "REMOVE: totalDelta should be > 0");
         } else if (operationType == PDPRecordKeeper.OperationType.PROVE_POSSESSION) {
             abi.decode(extraData, (uint256));
         } else if (operationType == PDPRecordKeeper.OperationType.DELETE) {
-            require(extraData.length == 0, "DELETE: extraData should be empty");
+            abi.decode(extraData, (uint256));
         } else {
             revert("Unknown operation type");
         }

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,5 +2,20 @@ A place for all tools related to running and developing the PDP service contract
 
 # Tools
 
-## TODO
-Nothing here yet
+## deploy-devnet.sh
+This script deploys the PDP service contract to a local filecoin devnet.  It assumes lotus binary is in path and local devnet is running with eth API enabled.  The keystore will be funded automatically from lotus default address. 
+
+## pdp scripts
+We have some scripts for interacting with the PDP service contract through ETH RPC API: 
+- add.sh
+- remove.sh
+- createproofset.sh
+- find.sh 
+- size.sh
+
+To use these scripts set the following environment variables:
+- KEYSTORE
+- PASSWORD
+- RPC_URL
+
+with values corresponding to local geth keystore path, the password for the keystore and the RPC URL for the network where PDP service contract is deployed. 

--- a/tools/createproofset.sh
+++ b/tools/createproofset.sh
@@ -8,15 +8,15 @@ if [ -z "$RPC_URL" ] || [ -z "$KEYSTORE" ] ; then
 fi
 
 # Get the contract address from the command line argument
-if [ -z "$1" ]; then
-    echo "Usage: $0 <contract_address>"
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: $0 <contract_address> <record_keeper_address>"
     exit 1
 fi
 
 CONTRACT_ADDRESS=$1
 
 # Create the calldata for createProofSet()
-CALLDATA=$(cast calldata "createProofSet()(uint256)")
+CALLDATA=$(cast calldata "createProofSet(address)(uint256)" $2)
 
 # Send the transaction
 cast send --keystore $KEYSTORE --password "$PASSWORD" --rpc-url $RPC_URL $CONTRACT_ADDRESS $CALLDATA


### PR DESCRIPTION
Closes #12, Closes #31
TODO
- [x] Add assertions of record keeping state to the end of all PDPService tests (create helpers for this) 
- [x] Add tests with faked PDPService contract that fails in different scenarios to ensure failures propagate
- [x] Update deploy shell script to deploy a record keeper 
- [x] Update createproofset shell script to include address of record keeper 