### PR TITLE
Rename record keeper as application

### DIFF
--- a/contracts/src/PDPRecordKeeper.sol
+++ b/contracts/src/PDPRecordKeeper.sol
@@ -1,38 +1,20 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import {PDPService} from "./PDPService.sol";
-
-interface PDPApplication {
-    enum OperationType {
-        NONE,
-        CREATE,
-        ADD,
-        REMOVE,
-        PROVE_POSSESSION,
-        DELETE
-    }
-
-    function notify(
-        uint256 proofSetId,
-        uint64 epoch,
-        OperationType operationType,
-        bytes calldata extraData
-    ) external;
-}
+import {PDPService, PDPListener} from "./PDPService.sol";
 
 // PDPRecordKeeperApplication is a default implementation of a PDP Application.
 // It maintains a record of all events that have occurred in the PDP service,
 // and provides a way to query these events.
 // This contract only supports one PDP service caller, set in the constructor.
-contract PDPRecordKeeperApplication is PDPApplication {
+contract PDPRecordKeeper is PDPListener {
     // The address of the PDP service contract that is allowed to call this contract
     address public immutable pdpServiceAddress;
 
     // Struct to store event details
     struct EventRecord {
         uint64 epoch;
-        PDPApplication.OperationType operationType;
+        PDPListener.OperationType operationType;
         bytes extraData;
     }
 
@@ -40,7 +22,7 @@ contract PDPRecordKeeperApplication is PDPApplication {
     mapping(uint256 => EventRecord[]) public proofSetEvents;
 
     // Eth event emitted when a new record is added
-    event RecordAdded(uint256 indexed proofSetId, uint64 epoch, PDPApplication.OperationType operationType);
+    event RecordAdded(uint256 indexed proofSetId, uint64 epoch, PDPListener.OperationType operationType);
 
     constructor(address _pdpServiceAddress) {
         require(_pdpServiceAddress != address(0), "PDP service address cannot be zero");
@@ -54,10 +36,10 @@ contract PDPRecordKeeperApplication is PDPApplication {
     }
 
     // Function to add a new event record
-    function notify(
+    function receiveProofSetEvent(
         uint256 proofSetId,
         uint64 epoch,
-        PDPApplication.OperationType operationType,
+        PDPListener.OperationType operationType,
         bytes calldata extraData
     ) external onlyPDPService {
         EventRecord memory newRecord = EventRecord({

--- a/contracts/test/PDPRecordKeeper.t.sol
+++ b/contracts/test/PDPRecordKeeper.t.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";
-import {PDPRecordKeeper} from "../src/PDPRecordKeeper.sol";
+import {PDPRecordKeeperApplication, PDPApplication} from "../src/PDPRecordKeeperApplication.sol";
 
 contract PDPRecordKeeperTest is Test {
-    PDPRecordKeeper public recordKeeper;
+    PDPRecordKeeperApplication public recordKeeper;
     address public pdpServiceAddress;
 
     function setUp() public {
         pdpServiceAddress = address(this);
-        recordKeeper = new PDPRecordKeeper(pdpServiceAddress);
+        recordKeeper = new PDPRecordKeeperApplication(pdpServiceAddress);
     }
 
     function testInitialState() public view {
@@ -20,14 +20,14 @@ contract PDPRecordKeeperTest is Test {
     function testAddRecord() public {
         uint256 proofSetId = 1;
         uint64 epoch = 100;
-        PDPRecordKeeper.OperationType operationType = PDPRecordKeeper.OperationType.CREATE;
+        PDPApplication.OperationType operationType = PDPApplication.OperationType.CREATE;
         bytes memory extraData = abi.encode("test data");
 
-        recordKeeper.addRecord(proofSetId, epoch, operationType, extraData);
+        recordKeeper.notify(proofSetId, epoch, operationType, extraData);
 
         assertEq(recordKeeper.getEventCount(proofSetId), 1, "Event count should be 1 after adding a record");
 
-        PDPRecordKeeper.EventRecord memory eventRecord = recordKeeper.getEvent(proofSetId, 0);
+        PDPRecordKeeperApplication.EventRecord memory eventRecord = recordKeeper.getEvent(proofSetId, 0);
 
         assertEq(eventRecord.epoch, epoch, "Recorded epoch should match");
         assertEq(uint(eventRecord.operationType), uint(operationType), "Recorded operation type should match");
@@ -38,15 +38,15 @@ contract PDPRecordKeeperTest is Test {
         uint256 proofSetId = 1;
         uint64 epoch1 = 100;
         uint64 epoch2 = 200;
-        PDPRecordKeeper.OperationType operationType1 = PDPRecordKeeper.OperationType.CREATE;
-        PDPRecordKeeper.OperationType operationType2 = PDPRecordKeeper.OperationType.ADD;
+        PDPApplication.OperationType operationType1 = PDPApplication.OperationType.CREATE;
+        PDPApplication.OperationType operationType2 = PDPApplication.OperationType.ADD;
         bytes memory extraData1 = abi.encode("test data 1");
         bytes memory extraData2 = abi.encode("test data 2");
 
-        recordKeeper.addRecord(proofSetId, epoch1, operationType1, extraData1);
-        recordKeeper.addRecord(proofSetId, epoch2, operationType2, extraData2);
+        recordKeeper.notify(proofSetId, epoch1, operationType1, extraData1);
+        recordKeeper.notify(proofSetId, epoch2, operationType2, extraData2);
 
-        PDPRecordKeeper.EventRecord[] memory events = recordKeeper.listEvents(proofSetId);
+        PDPRecordKeeperApplication.EventRecord[] memory events = recordKeeper.listEvents(proofSetId);
 
         assertEq(events.length, 2, "Should have 2 events");
         assertEq(events[0].epoch, epoch1, "First event epoch should match");
@@ -60,12 +60,12 @@ contract PDPRecordKeeperTest is Test {
     function testOnlyPDPServiceCanAddRecord() public {
         uint256 proofSetId = 1;
         uint64 epoch = 100;
-        PDPRecordKeeper.OperationType operationType = PDPRecordKeeper.OperationType.CREATE;
+        PDPApplication.OperationType operationType = PDPApplication.OperationType.CREATE;
         bytes memory extraData = abi.encode("test data");
 
         vm.prank(address(0xdead));
         vm.expectRevert("Caller is not the PDP service");
-        recordKeeper.addRecord(proofSetId, epoch, operationType, extraData);
+        recordKeeper.notify(proofSetId, epoch, operationType, extraData);
     }
 
     function testGetEventOutOfBounds() public {

--- a/contracts/test/PDPRecordKeeper.t.sol
+++ b/contracts/test/PDPRecordKeeper.t.sol
@@ -2,15 +2,16 @@
 pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";
-import {PDPRecordKeeperApplication, PDPApplication} from "../src/PDPRecordKeeperApplication.sol";
+import {PDPRecordKeeper} from "../src/PDPRecordKeeper.sol";
+import {PDPListener} from "../src/PDPService.sol";
 
 contract PDPRecordKeeperTest is Test {
-    PDPRecordKeeperApplication public recordKeeper;
+    PDPRecordKeeper public recordKeeper;
     address public pdpServiceAddress;
 
     function setUp() public {
         pdpServiceAddress = address(this);
-        recordKeeper = new PDPRecordKeeperApplication(pdpServiceAddress);
+        recordKeeper = new PDPRecordKeeper(pdpServiceAddress);
     }
 
     function testInitialState() public view {
@@ -20,14 +21,14 @@ contract PDPRecordKeeperTest is Test {
     function testAddRecord() public {
         uint256 proofSetId = 1;
         uint64 epoch = 100;
-        PDPApplication.OperationType operationType = PDPApplication.OperationType.CREATE;
+        PDPListener.OperationType operationType = PDPListener.OperationType.CREATE;
         bytes memory extraData = abi.encode("test data");
 
-        recordKeeper.notify(proofSetId, epoch, operationType, extraData);
+        recordKeeper.receiveProofSetEvent(proofSetId, epoch, operationType, extraData);
 
         assertEq(recordKeeper.getEventCount(proofSetId), 1, "Event count should be 1 after adding a record");
 
-        PDPRecordKeeperApplication.EventRecord memory eventRecord = recordKeeper.getEvent(proofSetId, 0);
+        PDPRecordKeeper.EventRecord memory eventRecord = recordKeeper.getEvent(proofSetId, 0);
 
         assertEq(eventRecord.epoch, epoch, "Recorded epoch should match");
         assertEq(uint(eventRecord.operationType), uint(operationType), "Recorded operation type should match");
@@ -38,15 +39,15 @@ contract PDPRecordKeeperTest is Test {
         uint256 proofSetId = 1;
         uint64 epoch1 = 100;
         uint64 epoch2 = 200;
-        PDPApplication.OperationType operationType1 = PDPApplication.OperationType.CREATE;
-        PDPApplication.OperationType operationType2 = PDPApplication.OperationType.ADD;
+        PDPListener.OperationType operationType1 = PDPListener.OperationType.CREATE;
+        PDPListener.OperationType operationType2 = PDPListener.OperationType.ADD;
         bytes memory extraData1 = abi.encode("test data 1");
         bytes memory extraData2 = abi.encode("test data 2");
 
-        recordKeeper.notify(proofSetId, epoch1, operationType1, extraData1);
-        recordKeeper.notify(proofSetId, epoch2, operationType2, extraData2);
+        recordKeeper.receiveProofSetEvent(proofSetId, epoch1, operationType1, extraData1);
+        recordKeeper.receiveProofSetEvent(proofSetId, epoch2, operationType2, extraData2);
 
-        PDPRecordKeeperApplication.EventRecord[] memory events = recordKeeper.listEvents(proofSetId);
+        PDPRecordKeeper.EventRecord[] memory events = recordKeeper.listEvents(proofSetId);
 
         assertEq(events.length, 2, "Should have 2 events");
         assertEq(events[0].epoch, epoch1, "First event epoch should match");
@@ -60,12 +61,12 @@ contract PDPRecordKeeperTest is Test {
     function testOnlyPDPServiceCanAddRecord() public {
         uint256 proofSetId = 1;
         uint64 epoch = 100;
-        PDPApplication.OperationType operationType = PDPApplication.OperationType.CREATE;
+        PDPListener.OperationType operationType = PDPListener.OperationType.CREATE;
         bytes memory extraData = abi.encode("test data");
 
         vm.prank(address(0xdead));
         vm.expectRevert("Caller is not the PDP service");
-        recordKeeper.notify(proofSetId, epoch, operationType, extraData);
+        recordKeeper.receiveProofSetEvent(proofSetId, epoch, operationType, extraData);
     }
 
     function testGetEventOutOfBounds() public {


### PR DESCRIPTION
This is a light refactor as the outcome of exploring what PDP application conventions could look like.  This change cements the decision for applications to interact with PDP by getting called back with different operations.

Alternatively we could have had an interface with separate methods for notifying each operation but I didn't see a compelling enough case for this.