### PR TITLE
Proving specification hints now given in the PDP application

### DIFF
--- a/contracts/src/PDPRecordKeeper.sol
+++ b/contracts/src/PDPRecordKeeper.sol
@@ -70,4 +70,17 @@ contract PDPRecordKeeper is PDPListener {
     function listEvents(uint256 proofSetId) external view returns (EventRecord[] memory) {
         return proofSetEvents[proofSetId];
     }
+
+    // SLA specification functions setting values for PDP service providers
+
+    // Max number of epochs between two consecutive proofs
+    function getMaxProvingPeriod() public pure returns (uint64) {
+        return 2880;
+    }
+
+    // Challenges / merkle inclusion proofs provided per proof set
+    function getChallengesPerProof() public pure returns (uint64) {
+        // TODO: don't know this yet
+        return 5;
+    }
 }

--- a/contracts/test/PDPRecordKeeper.t.sol
+++ b/contracts/test/PDPRecordKeeper.t.sol
@@ -14,6 +14,16 @@ contract PDPRecordKeeperTest is Test {
         recordKeeper = new PDPRecordKeeper(pdpServiceAddress);
     }
 
+    function testGetMaxProvingPeriod() public view {
+        uint64 maxPeriod = recordKeeper.getMaxProvingPeriod();
+        assertEq(maxPeriod, 2880, "Max proving period should be 2880");
+    }
+
+    function testGetChallengesPerProof() public view{
+        uint64 challenges = recordKeeper.getChallengesPerProof();
+        assertEq(challenges, 5, "Challenges per proof should be 5");
+    }
+
     function testInitialState() public view {
         assertEq(recordKeeper.pdpServiceAddress(), pdpServiceAddress, "PDP service address should be set correctly");
     }


### PR DESCRIPTION
With a slight shift in perspective the record keeper is now the first instance of our default PDP application.  This PR augments our default application to tell users what proving period and challenge count should be.

@magik6k I think this is most of what you need to avoid configuration state outside of the chain.  This is flexible enough where it allows proving early which should make setting a proving offset a moot point.  Basically lets say you first add data at 2:30 AM which samples a challenge.  The next day you could prove at 2 PM and then you don't need to prove again until 2 PM.