### PR TITLE
Exercise Precompile 

### DIFF
--- a/contracts/src/RandomnessTest.sol
+++ b/contracts/src/RandomnessTest.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.20;
 
 contract RandomnessTest {
     // Address of the randomness precompile
-    address constant RANDOMNESS_PRECOMPILE = address(0x00fe00000000000000000000000000000000000006);
+    address constant RANDOMNESS_PRECOMPILE = 0xfE00000000000000000000000000000000000006;
 
     function getRandomness(uint64 epoch) public view returns (bytes32) {
         // Prepare the input data (epoch as a uint256)
         uint256 input = uint256(epoch);
 
         // Call the precompile
-        (bool success, bytes memory result) = RANDOMNESS_PRECOMPILE.staticcall(abi.encode(input));
+        (bool success, bytes memory result) = RANDOMNESS_PRECOMPILE.staticcall(abi.encodePacked(input));
 
         // Check if the call was successful
         require(success, "Randomness precompile call failed");
@@ -19,12 +19,15 @@ contract RandomnessTest {
         return abi.decode(result, (bytes32));
     }
 
+    function getLookbackRandomness(uint64 lookback) public view returns (bytes32) {
+        return getRandomness(uint64(block.number) - lookback);
+    }
+
     function getRawRandomness(uint64 epoch) public view returns (bool,bytes memory) {
         // Prepare the input data (epoch as a uint256)
         uint256 input = uint256(epoch);
 
         // Call the precompile
-        (bool success, bytes memory result) = RANDOMNESS_PRECOMPILE.staticcall(abi.encode(input));
-        return(success, result);
+        return RANDOMNESS_PRECOMPILE.staticcall(abi.encodePacked(input));
     }
 }

--- a/contracts/src/RandomnessTest.sol
+++ b/contracts/src/RandomnessTest.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract RandomnessTest {
+    // Address of the randomness precompile
+    address constant RANDOMNESS_PRECOMPILE = address(0x00fe00000000000000000000000000000000000006);
+
+    function getRandomness(uint64 epoch) public view returns (bytes32) {
+        // Prepare the input data (epoch as a uint256)
+        uint256 input = uint256(epoch);
+
+        // Call the precompile
+        (bool success, bytes memory result) = RANDOMNESS_PRECOMPILE.staticcall(abi.encode(input));
+
+        // Check if the call was successful
+        require(success, "Randomness precompile call failed");
+
+        // Decode and return the result
+        return abi.decode(result, (bytes32));
+    }
+
+    function getRawRandomness(uint64 epoch) public view returns (bool,bytes memory) {
+        // Prepare the input data (epoch as a uint256)
+        uint256 input = uint256(epoch);
+
+        // Call the precompile
+        (bool success, bytes memory result) = RANDOMNESS_PRECOMPILE.staticcall(abi.encode(input));
+        return(success, result);
+    }
+}


### PR DESCRIPTION
Now that there is a lotus RC with the nv24 candidate we can check in to confirm that it's working.  This contract just returns the precompile output for provided inputs.

This is the first step towards #44 