### PR TITLE
Enforce challenge count in simple pdp service

### DIFF
--- a/contracts/src/SimplePDPService.sol
+++ b/contracts/src/SimplePDPService.sol
@@ -6,8 +6,6 @@ import "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initiali
 import "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "../lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
 
-
-
 // PDPRecordKeeper tracks PDP operations.  It is used as a base contract for PDPListeners
 // in order to give users the capability to consume events async.
 contract PDPRecordKeeper {
@@ -35,7 +33,7 @@ contract PDPRecordKeeper {
     // Mapping to store events for each proof set
     mapping(uint256 => EventRecord[]) public proofSetEvents;
 
-    function receiveProofSetEvent(uint256 proofSetId, OperationType operationType, bytes memory extraData ) internal {
+    function receiveProofSetEvent(uint256 proofSetId, OperationType operationType, bytes memory extraData ) internal returns(uint256) {
         uint64 epoch = uint64(block.number);
         EventRecord memory newRecord = EventRecord({
             epoch: epoch,
@@ -45,6 +43,7 @@ contract PDPRecordKeeper {
         });
         proofSetEvents[proofSetId].push(newRecord);
         emit RecordAdded(proofSetId, epoch, operationType);
+        return proofSetEvents[proofSetId].length - 1;
     }
 
     // Function to get the number of events for a proof set
@@ -73,27 +72,50 @@ contract PDPRecordKeeper {
 // and provides a way to query these events.
 // This contract only supports one PDP service caller, set in the constructor.
 contract SimplePDPService is PDPListener, PDPRecordKeeper, Initializable, UUPSUpgradeable, OwnableUpgradeable {
-    // The address of the PDP service contract that is allowed to call this contract
-    address public pdpServiceAddress;
+
+    enum FaultType {
+        NONE,
+        LATE,
+        SKIPPED
+    }
+
+    event Debug(string message, uint256 value);
+    event FaultRecord(FaultType faultType, uint256 periodsFaulted);
+
+    // The address of the PDP verifier contract that is allowed to call this contract
+    address public pdpVerifierAddress;
+    mapping(uint256 => uint256) public provingDeadlines;
+    mapping(uint256 => bool) public provenThisPeriod;
 
      /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
      _disableInitializers();
     }
 
-    function initialize(address _pdpServiceAddress) public initializer {
+    function initialize(address _pdpVerifierAddress) public initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
-require(_pdpServiceAddress != address(0), "PDP service address cannot be zero");
-        pdpServiceAddress = _pdpServiceAddress;
+        require(_pdpVerifierAddress != address(0), "PDP verifier address cannot be zero");
+        pdpVerifierAddress = _pdpVerifierAddress;
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     // Modifier to ensure only the PDP verifier contract can call certain functions
     modifier onlyPDPVerifier() {
-        require(msg.sender == pdpServiceAddress, "Caller is not the PDP verifier");
+        require(msg.sender == pdpVerifierAddress, "Caller is not the PDP verifier");
         _;
+    }
+
+    // SLA specification functions setting values for PDP service providers
+    // Max number of epochs between two consecutive proofs
+    function getMaxProvingPeriod() public pure returns (uint64) {
+        return 2880;
+    }
+
+    // Challenges / merkle inclusion proofs provided per proof set
+    function getChallengesPerProof() public pure returns (uint64) {
+        return 5;
     }
 
     // Listener interface methods
@@ -106,6 +128,9 @@ require(_pdpServiceAddress != address(0), "PDP service address cannot be zero");
     }
 
     function rootsAdded(uint256 proofSetId, uint256 firstAdded, PDPVerifier.RootData[] memory rootData) external onlyPDPVerifier {
+        if (firstAdded == 0) {
+            provingDeadlines[proofSetId] = block.number + getMaxProvingPeriod();
+        }
         receiveProofSetEvent(proofSetId, OperationType.ADD, abi.encode(firstAdded, rootData));
     }
 
@@ -113,11 +138,41 @@ require(_pdpServiceAddress != address(0), "PDP service address cannot be zero");
         receiveProofSetEvent(proofSetId, OperationType.REMOVE_SCHEDULED, abi.encode(rootIds));
     }
 
+    // possession proven checks for correct challenge count and reverts if too low
+    // it also checks that proofs are not late and emits a fault record if so
     function posessionProven(uint256 proofSetId, uint256 challengedLeafCount, uint256 seed, uint256 challengeCount) external onlyPDPVerifier {
         receiveProofSetEvent(proofSetId, OperationType.PROVE_POSSESSION, abi.encode(challengedLeafCount, seed, challengeCount));
+        emit Debug("Here we go", 0);
+        if (provenThisPeriod[proofSetId]) { 
+            // return immediately, we've already witnessed a proof for this proof set this period
+            return; 
+        }
+
+        if (challengeCount < getChallengesPerProof()) {
+            revert("Invalid challenge count < 5");
+        }
+        emit Debug("deadline", provingDeadlines[proofSetId]);
+        emit Debug("block number", block.number);
+        // check for late proof 
+        if (provingDeadlines[proofSetId] < block.number) {
+            uint256 periodsLate = 1 + ((block.number - provingDeadlines[proofSetId]) / getMaxProvingPeriod());
+            emit Debug("we're late", periodsLate); 
+            emit FaultRecord(FaultType.LATE, periodsLate);
+        }
+        provenThisPeriod[proofSetId] = true;
     }
 
+    // nextProvingPeriod checks for unsubmitted proof and emits a fault record if so
     function nextProvingPeriod(uint256 proofSetId, uint256 leafCount) external onlyPDPVerifier {
         receiveProofSetEvent(proofSetId, OperationType.NEXT_PROVING_PERIOD, abi.encode(leafCount));
+        // check for unsubmitted proof 
+        if (!provenThisPeriod[proofSetId]) {
+            uint256 periodsSkipped = 1;
+            if (provingDeadlines[proofSetId] < block.number) {
+                periodsSkipped = 1 + ((block.number - provingDeadlines[proofSetId]) / getMaxProvingPeriod());
+            }
+            emit FaultRecord(FaultType.SKIPPED, periodsSkipped);
+        }
+        provenThisPeriod[proofSetId] = false;
     }
 }

--- a/contracts/test/SimplePDPService.t.sol
+++ b/contracts/test/SimplePDPService.t.sol
@@ -10,18 +10,18 @@ import {Cids} from "../src/Cids.sol";
 
 contract SimplePDPServiceTest is Test {
     SimplePDPService public pdpService;
-    address public pdpServiceAddress;
+    address public pdpVerifierAddress;
 
     function setUp() public {
-        pdpServiceAddress = address(this);
+        pdpVerifierAddress = address(this);
         SimplePDPService pdpServiceImpl = new SimplePDPService();
-        bytes memory initializeData = abi.encodeWithSelector(SimplePDPService.initialize.selector, address(pdpServiceAddress));
+        bytes memory initializeData = abi.encodeWithSelector(SimplePDPService.initialize.selector, address(pdpVerifierAddress));
         MyERC1967Proxy pdpServiceProxy = new MyERC1967Proxy(address(pdpServiceImpl), initializeData);
         pdpService = SimplePDPService(address(pdpServiceProxy));
     }
 
     function testInitialState() public view {
-        assertEq(pdpService.pdpServiceAddress(), pdpServiceAddress, "PDP verifier address should be set correctly");
+        assertEq(pdpService.pdpVerifierAddress(), pdpVerifierAddress, "PDP verifier address should be set correctly");
     }
 
     function testAddRecord() public {
@@ -77,5 +77,101 @@ contract SimplePDPServiceTest is Test {
         uint256 proofSetId = 1;
         vm.expectRevert("Event index out of bounds");
         pdpService.getEvent(proofSetId, 0);
+    }
+
+    function testGetMaxProvingPeriod() public view {
+        uint64 maxPeriod = pdpService.getMaxProvingPeriod();
+        assertEq(maxPeriod, 2880, "Max proving period should be 2880");
+    }
+
+    function testGetChallengesPerProof() public view{
+        uint64 challenges = pdpService.getChallengesPerProof();
+        assertEq(challenges, 5, "Challenges per proof should be 5");
+    }
+}
+
+contract SimplePDPServiceFaultsTest is Test {
+    SimplePDPService public pdpService;
+    address public pdpVerifierAddress;
+
+    function setUp() public {
+        pdpVerifierAddress = address(this);
+        SimplePDPService pdpServiceImpl = new SimplePDPService();
+        bytes memory initializeData = abi.encodeWithSelector(SimplePDPService.initialize.selector, address(pdpVerifierAddress));
+        MyERC1967Proxy pdpServiceProxy = new MyERC1967Proxy(address(pdpServiceImpl), initializeData);
+        pdpService = SimplePDPService(address(pdpServiceProxy));
+    }
+
+    function testPosessionProvenOnTime() public {
+        uint256 proofSetId = 1;
+        uint256 challengedLeafCount = 100;
+        uint256 seed = 12345;
+        uint256 challengeCount = 5;
+
+        // Set up the proving deadline
+        pdpService.rootsAdded(proofSetId, 0, new PDPVerifier.RootData[](0));
+        // Warp to just before the deadline
+        vm.warp(block.number + pdpService.getMaxProvingPeriod() - 1);
+        pdpService.posessionProven(proofSetId, challengedLeafCount, seed, challengeCount);
+        assertTrue(pdpService.provenThisPeriod(proofSetId));
+    }
+
+    function testPosessionProvenLate() public {
+        uint256 proofSetId = 1;
+        uint256 challengedLeafCount = 100;
+        uint256 seed = 12345;
+        uint256 challengeCount = 5;
+
+        // Set up the proving deadline
+        pdpService.rootsAdded(proofSetId, 0, new PDPVerifier.RootData[](0));
+        // Warp to after the deadline
+        vm.roll(block.number + pdpService.getMaxProvingPeriod() + 1);
+        //Expect a LATE fault event
+        vm.expectEmit();
+        emit SimplePDPService.FaultRecord(SimplePDPService.FaultType.LATE, 1);
+        pdpService.posessionProven(proofSetId, challengedLeafCount, seed, challengeCount);
+        assertTrue(pdpService.provenThisPeriod(proofSetId));
+    }
+
+    function testNextProvingPeriodWithoutProof() public {
+        uint256 proofSetId = 1;
+        uint256 leafCount = 100;
+
+        // Set up the proving deadline without marking as proven
+        pdpService.rootsAdded(proofSetId, 0, new PDPVerifier.RootData[](0));
+        // Move to the next period
+        vm.roll(block.number + pdpService.getMaxProvingPeriod() + 1);
+        // Expect a SKIPPED fault event
+        vm.expectEmit();
+        emit SimplePDPService.FaultRecord(SimplePDPService.FaultType.SKIPPED, 1);
+        pdpService.nextProvingPeriod(proofSetId, leafCount);
+        assertFalse(pdpService.provenThisPeriod(proofSetId));
+    }
+
+    function testInvalidChallengeCount() public {
+        uint256 proofSetId = 1;
+        uint256 challengedLeafCount = 100;
+        uint256 seed = 12345;
+        uint256 invalidChallengeCount = 4; // Less than required
+
+        pdpService.rootsAdded(proofSetId, 0, new PDPVerifier.RootData[](0));
+        vm.expectRevert("Invalid challenge count < 5");
+        pdpService.posessionProven(proofSetId, challengedLeafCount, seed, invalidChallengeCount);
+    }
+
+    function testMultiplePeriodsLate() public {
+        uint256 proofSetId = 1;
+        uint256 challengedLeafCount = 100;
+        uint256 seed = 12345;
+        uint256 challengeCount = 5;
+
+        // Set up the proving deadline
+        pdpService.rootsAdded(proofSetId, 0, new PDPVerifier.RootData[](0));
+        // Warp to 3 periods after the deadline
+        vm.roll(block.number + pdpService.getMaxProvingPeriod() * 3 + 1);
+        // Expect a LATE fault event with 3 periods
+        vm.expectEmit();
+        emit SimplePDPService.FaultRecord(SimplePDPService.FaultType.LATE, 3);
+        pdpService.posessionProven(proofSetId, challengedLeafCount, seed, challengeCount);
     }
 }

--- a/contracts/test/SimplePDPService.t.sol
+++ b/contracts/test/SimplePDPService.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";
 import {PDPListener, PDPVerifier} from "../src/PDPVerifier.sol";
-import {SimplePDPService} from "../src/SimplePDPService.sol";
+import {SimplePDPService, PDPRecordKeeper} from "../src/SimplePDPService.sol";
 import {MyERC1967Proxy} from "../src/ERC1967Proxy.sol";
 import {Cids} from "../src/Cids.sol";
 
@@ -35,7 +35,7 @@ contract SimplePDPServiceTest is Test {
         SimplePDPService.EventRecord memory eventRecord = pdpService.getEvent(proofSetId, 0);
 
         assertEq(eventRecord.epoch, epoch, "Recorded epoch should match");
-        assertEq(uint(eventRecord.operationType), uint(SimplePDPService.OperationType.CREATE), "Recorded operation type should match");
+        assertEq(uint(eventRecord.operationType), uint(PDPRecordKeeper.OperationType.CREATE), "Recorded operation type should match");
         assertEq(eventRecord.extraData, abi.encode(address(this)), "Recorded extra data should match");
     }
 
@@ -57,11 +57,11 @@ contract SimplePDPServiceTest is Test {
 
         assertEq(events.length, 2, "Should have 2 events");
         assertEq(events[0].epoch, epoch1, "First event epoch should match");
-        assertEq(uint(events[0].operationType), uint(SimplePDPService.OperationType.CREATE), "First event operation type should match");
+        assertEq(uint(events[0].operationType), uint(PDPRecordKeeper.OperationType.CREATE), "First event operation type should match");
         assertEq(events[0].extraData, abi.encode(address(this)), "First event extra data should match");
 
         assertEq(events[1].epoch, epoch2, "Second event epoch should match");
-        assertEq(uint(events[1].operationType), uint(SimplePDPService.OperationType.ADD), "Second event operation type should match");
+        assertEq(uint(events[1].operationType), uint(PDPRecordKeeper.OperationType.ADD), "Second event operation type should match");
         assertEq(events[1].extraData, abi.encode(firstRoot, rootData), "Second event extra data should match");
     }
 


### PR DESCRIPTION
As part of requirements we want to allow on chain enforcement of challenge count during proving without baking assumptions directly in the pdp verifier.

So we want to put this in the simple pdp service.  To do this well wrt testing we want to refactor simple pdp service a bit.  This PR extracts record keeper functionality to a base contract that can be shared by simple pdp service and a testing contract that forgoes the complexity of simple pdp service.  

This PR also introduces functions on simple pdp service that make discovery of faults easy for off chain observers. 