### PR TITLE
Pin solc version in foundry.toml

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -2,5 +2,5 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-
+solc_version = "0.8.23"
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/tools/deploy-calibnet.sh
+++ b/tools/deploy-calibnet.sh
@@ -18,7 +18,7 @@ fi
 
 echo "Deploying PDP verifier"
 # Parse the output of forge create to extract the contract address
-PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 314159 contracts/src/PDPVerifier.sol:PDPVerifier --constructor-args 3 | grep "Deployed to" | awk '{print $3}')
+PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 314159 contracts/src/PDPVerifier.sol:PDPVerifier --constructor-args 3 | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract PDP service contract address"
@@ -28,9 +28,9 @@ echo "PDP service implementation deployed at: $IMPLEMENTATION_ADDRESS"
 
 echo "Deploying PDP service proxy"
 INIT_DATA=$(cast calldata "initialize(uint256)" 3)
-PDP_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 314159 src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $IMPLEMENTATION_ADDRESS $INIT_DATA | grep "Deployed to" | awk '{print $3}')
+PDP_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 314159 src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $IMPLEMENTATION_ADDRESS $INIT_DATA | grep "Deployed to" | awk '{print $3}')
 
 echo "PDP verifier deployed at: $PDP_VERIFIER_ADDRESS"
 
 echo "Deploying PDP Service"
-forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 314159 contracts/src/SimplePDPService.sol:SimplePDPService --constructor-args $PDP_VERIFIER_ADDRESS
+forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 314159 contracts/src/SimplePDPService.sol:SimplePDPService --constructor-args $PDP_VERIFIER_ADDRESS

--- a/tools/deploy-devnet.sh
+++ b/tools/deploy-devnet.sh
@@ -25,7 +25,7 @@ lotus send $clientAddr 10000
 # Deploy PDP service contract
 echo "Deploying PDP service"
 # Parse the output of forge create to extract the contract address
-PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 31415926 contracts/src/PDPVerifier.sol:PDPVerifier --constructor-args 3 | grep "Deployed to" | awk '{print $3}')
+PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 31415926 contracts/src/PDPVerifier.sol:PDPVerifier --constructor-args 3 | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$PDP_VERIFIER_ADDRESS" ]; then
     echo "Error: Failed to extract PDP verifier contract address"
@@ -36,4 +36,4 @@ echo "PDP service deployed at: $PDP_VERIFIER_ADDRESS"
 
 # Deploy PDP Record keeper 
 echo "Deploying PDP Service"
-forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 31415926 contracts/src/SimplePDPService.sol:SimplePDPService --constructor-args $PDP_VERIFIER_ADDRESS
+forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 31415926 contracts/src/SimplePDPService.sol:SimplePDPService --constructor-args $PDP_VERIFIER_ADDRESS

--- a/tools/testBurnFee.sh
+++ b/tools/testBurnFee.sh
@@ -25,7 +25,7 @@ lotus send $clientAddr 10000
 # Deploy PDP service contract
 echo "Deploying PDP service"
 # Parse the output of forge create to extract the contract address
-PDP_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 31415926 contracts/src/PDPService.sol:PDPService --constructor-args 3 | grep "Deployed to" | awk '{print $3}')
+PDP_SERVICE_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 31415926 contracts/src/PDPService.sol:PDPService --constructor-args 3 | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$PDP_SERVICE_ADDRESS" ]; then
     echo "Error: Failed to extract PDP service contract address"

--- a/tools/upgrade-contract-calibnet.sh
+++ b/tools/upgrade-contract-calibnet.sh
@@ -34,7 +34,7 @@ fi
 
 echo "Deploying new $IMPLEMENTATION_PATH implementation contract"
 # Parse the output of forge create to extract the contract address
-IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.20 --chain-id 314159 "$IMPLEMENTATION_PATH" | grep "Deployed to" | awk '{print $3}')
+IMPLEMENTATION_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --compiler-version 0.8.23 --chain-id 314159 "$IMPLEMENTATION_PATH" | grep "Deployed to" | awk '{print $3}')
 
 if [ -z "$IMPLEMENTATION_ADDRESS" ]; then
     echo "Error: Failed to extract PDP verifier contract address"


### PR DESCRIPTION
For whatever reason, when running solidity 0.8.20, we get a visibility error in the tests:

```
Error (9582): Member "FaultRecord" not found or not visible after argument-dependent lookup in type(contract SimplePDPService).
   --> test/SimplePDPService.t.sol:188:14:
    |
188 |         emit SimplePDPService.FaultRecord(SimplePDPService.FaultType.LATE, 3);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```